### PR TITLE
[DINO-22] Adjacency improvements

### DIFF
--- a/Assets/Resources/Data/Actions/ActionFog_Remove_Selected.asset
+++ b/Assets/Resources/Data/Actions/ActionFog_Remove_Selected.asset
@@ -13,5 +13,10 @@ MonoBehaviour:
   m_Name: ActionFog_Remove_Selected
   m_EditorClassIdentifier: 
   Status: 1
+  Location: 0
   m_enable: 0
   m_includeNeighbors: 0
+  m_suppressEvent: 0
+  m_tileSearchParameters:
+    SearchRadius: 0
+    InfiniteSearchRadius: 0

--- a/Assets/Resources/Data/Actions/ActionFog_Remove_Selected_NoEvent.asset
+++ b/Assets/Resources/Data/Actions/ActionFog_Remove_Selected_NoEvent.asset
@@ -17,3 +17,6 @@ MonoBehaviour:
   m_enable: 0
   m_includeNeighbors: 0
   m_suppressEvent: 1
+  m_tileSearchParameters:
+    SearchRadius: 0
+    InfiniteSearchRadius: 0

--- a/Assets/Resources/Data/Actions/ActionFog_Remove_Target.asset
+++ b/Assets/Resources/Data/Actions/ActionFog_Remove_Target.asset
@@ -16,3 +16,7 @@ MonoBehaviour:
   Location: 2
   m_enable: 0
   m_includeNeighbors: 0
+  m_suppressEvent: 0
+  m_tileSearchParameters:
+    SearchRadius: 0
+    InfiniteSearchRadius: 0

--- a/Assets/Scripts/Editor/CheatWindow.cs
+++ b/Assets/Scripts/Editor/CheatWindow.cs
@@ -32,7 +32,7 @@ namespace Editor
 
                 foreach (var tile in ServiceLocator.Instance.World.Grid)
                 {
-                    ServiceLocator.Instance.World.ToggleFog(tile, false, false);
+                    ServiceLocator.Instance.World.ToggleFog(tile, false, null);
                 }
             }
             
@@ -46,7 +46,7 @@ namespace Editor
                 foreach (var tile in ServiceLocator.Instance.World.Grid)
                 {
                     var random = Random.Range(0, 2);
-                    ServiceLocator.Instance.World.ToggleFog(tile, random == 0, false);
+                    ServiceLocator.Instance.World.ToggleFog(tile, random == 0, null);
                 }
             }
             

--- a/Assets/Scripts/Gameplay/Deck.cs
+++ b/Assets/Scripts/Gameplay/Deck.cs
@@ -60,13 +60,18 @@ namespace Gameplay
         /// Returns the card at the very top of the deck. It is removed from the deck.
         /// </summary>
         /// <returns></returns>
-        public Card Pop()
+        public bool TryPop(out Card card)
         {
+            if (IsEmpty())
+            {
+                card = null;
+                return false;
+            }
             Assert.IsFalse(IsEmpty());
-            Card card = m_cards[0];
+            card = m_cards[0];
             m_cards.RemoveAt(0);
             CardCount.Value = m_cards.Count;
-            return card;
+            return true;
         }
 
         /// <summary>

--- a/Assets/Scripts/Gameplay/Loadout.cs
+++ b/Assets/Scripts/Gameplay/Loadout.cs
@@ -91,8 +91,11 @@ namespace Gameplay
             {
                 ShuffleDiscardToDeck();
             }
-            
-            Card card = Deck.Pop();
+
+            if (!Deck.TryPop(out Card card))
+            {
+                return false;
+            }
             Hand.AddCard(card);
             card.Invoker.TryInvokeActions(Invoker.EventType.CardOnDraw, card.Invoker.GetDefaultContext());
             OnDrawEvent?.Invoke(card);
@@ -169,7 +172,10 @@ namespace Gameplay
             Discard.Shuffle();
             while (!Discard.IsEmpty())
             {
-                Deck.AddCard(Discard.Pop());
+                if (Discard.TryPop(out Card card))
+                {
+                    Deck.AddCard(card);
+                }
             }
         }
     }

--- a/Assets/Scripts/Gameplay/Tile.cs
+++ b/Assets/Scripts/Gameplay/Tile.cs
@@ -12,6 +12,9 @@ namespace Gameplay
     public class Tile : MonoBehaviour, IPointerClickHandler, IInvoker, ITooltipable
     {
         public static int c_maxCapacity = 4;
+
+        public int X => m_x;
+        public int Y => m_y;
         
         public Invoker Invoker { get; private set; } = new Invoker();
         
@@ -24,6 +27,9 @@ namespace Gameplay
         
         public List<Structure> m_structures;
         private int m_capacity;
+
+        private int m_x;
+        private int m_y;
 
         private void Awake()
         {
@@ -49,6 +55,12 @@ namespace Gameplay
             Invoker.Initialize(this, Schema);
 
             m_capacity = schema.Capacity;
+        }
+
+        public void SetPosition(int x, int y)
+        {
+            m_x = x;
+            m_y = y;
         }
         
         public void OnPointerClick(PointerEventData eventData)

--- a/Assets/Scripts/Schemas/Actions/ActionFog.cs
+++ b/Assets/Scripts/Schemas/Actions/ActionFog.cs
@@ -9,6 +9,7 @@ namespace Schemas.Actions
         [SerializeField] private bool m_enable;
         [SerializeField] private bool m_includeNeighbors;
         [SerializeField] private bool m_suppressEvent;
+        [SerializeField] private TileSearchParameters m_tileSearchParameters;
 
         public override void Invoke(Invoker.Context context)
         {
@@ -29,7 +30,7 @@ namespace Schemas.Actions
             ServiceLocator.Instance.World.ToggleFog(
                 tile,
                 false,
-                m_includeNeighbors,
+                m_includeNeighbors ? m_tileSearchParameters : null,
                 !m_suppressEvent
             );
         }

--- a/Assets/Scripts/Schemas/TileSearchParameters.cs
+++ b/Assets/Scripts/Schemas/TileSearchParameters.cs
@@ -1,0 +1,14 @@
+using System;
+using Schemas;
+using UnityEngine;
+
+namespace Schemas
+{
+    [Serializable]
+    public class TileSearchParameters
+    {
+        public TileSchema.TileType? TileType;
+        public int SearchRadius = 1;
+        public bool InfiniteSearchRadius = false;
+    }
+}

--- a/Assets/Scripts/Schemas/TileSearchParameters.cs.meta
+++ b/Assets/Scripts/Schemas/TileSearchParameters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 488dea26a913141cfa20f1cffc2cb472
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Jira Task: https://dino-calamity.atlassian.net/browse/DINO-22

Add tile search parameters as a new serialized schema type that can be passed through to the GetNeighbors method.
Currently this will allow your to filter the neighbors you search for by:
- a specific tile type 
- range

For example, you can search for all connected neighbors of type lava, with a maximum range of 5 tiles away. 

<img width="596" alt="Screenshot 2024-08-14 at 11 28 37 PM" src="https://github.com/user-attachments/assets/b7ef1d50-82db-4758-b344-34f05a11d8dc">

